### PR TITLE
feat(search): Implement advanced Korean text search with korean-regexp

### DIFF
--- a/miniProjects/pokeapi/package.json
+++ b/miniProjects/pokeapi/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.4.0",
     "axios": "^1.7.8",
+    "korean-regexp": "^1.0.13",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/miniProjects/pokeapi/src/pages/Search.jsx
+++ b/miniProjects/pokeapi/src/pages/Search.jsx
@@ -2,6 +2,7 @@ import { useSearchParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import styled from 'styled-components';
+import { getRegExp } from 'korean-regexp';
 import { Card, PokemonImage, PokemonInfo } from "../styles/CardStyles";
 import { typeColors } from "../styles/constants";
 
@@ -44,10 +45,19 @@ function Search() {
   const pokemons = useSelector((state) => state.pokemon?.pokemons || []);
   const favorites = useSelector((state) => state.pokemon?.favorites || []);
 
-  // Filter Pokemon based on search query
+  // Filter Pokemon based on search query using korean-regexp
   const filteredPokemons = pokemons.filter(pokemon => {
-    const searchRegex = new RegExp(query, "i"); // Case-insensitive search
-    return searchRegex.test(pokemon.name_ko || pokemon.name);
+    // If no query, return all Pokemon
+    if (!query) return true;
+
+    // Create Korean-friendly regex
+    const koreanRegex = getRegExp(query);
+
+    // Check both Korean and English names
+    return (
+      (pokemon.name_ko && koreanRegex.test(pokemon.name_ko)) || 
+      koreanRegex.test(pokemon.name)
+    );
   });
 
   // Show message if no Pokemon found
@@ -91,7 +101,7 @@ function Search() {
                       key={type.type.name}
                       className="type-badge"
                       style={{
-                        backgroundColor: typeColors[type.type.name_ko],
+                        backgroundColor: typeColors[type.type.name_ko] || '#777',
                       }}
                     >
                       {type.type.name_ko || type.type.name}


### PR DESCRIPTION
Add robust Korean name filtering for Pokemon search

Integrate korean-regexp for advanced text matching
Support partial and fuzzy Korean name searches
Fallback to English name if Korean name is unavailable
Improve search experience with more flexible filtering